### PR TITLE
Project/apollo controller

### DIFF
--- a/code/defines/procs/announcement.dm
+++ b/code/defines/procs/announcement.dm
@@ -46,7 +46,7 @@
 				targets.Remove(H)
 
 		var/datum/ares_link/link = GLOB.ares_link
-		if(link.interface && !(link.interface.inoperable()))
+		if(ares_can_log())
 			switch(logging)
 				if(ARES_LOG_MAIN)
 					link.log_ares_announcement(title, message)
@@ -99,7 +99,7 @@
 		INVOKE_ASYNC(AI, TYPE_PROC_REF(/mob/living/silicon/decoy/ship_ai, say), message)
 
 	var/datum/ares_link/link = GLOB.ares_link
-	if(link.interface && !(link.interface.inoperable()))
+	if(ares_can_log())
 		switch(logging)
 			if(ARES_LOG_MAIN)
 				link.log_ares_announcement("[MAIN_AI_SYSTEM] Comms Update", message)
@@ -151,7 +151,7 @@
 			targets.Remove(T)
 
 	var/datum/ares_link/link = GLOB.ares_link
-	if(link.interface && !(link.interface.inoperable()))
+	if(ares_can_log())
 		link.log_ares_announcement("[title] Shipwide Update", message)
 
 	announcement_helper(message, title, targets, sound_to_play)

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -122,8 +122,9 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 		var/name = "[MAIN_AI_SYSTEM] Bioscan Status"
 		var/input = "Bioscan failed. \n\nInvestigation into Bioscan subsystem recommended."
 		if(ares_can_log())
+			link.log_ares_bioscan(name, input)
+		if(ares_can_interface())
 			marine_announcement(input, name, 'sound/misc/interference.ogg', logging = ARES_LOG_NONE)
-		link.log_ares_bioscan(name, input)
 		return
 
 	//Adjust the randomness there so everyone gets the same thing
@@ -132,8 +133,9 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 	var/name = "[MAIN_AI_SYSTEM] Bioscan Status"
 	var/input = "Bioscan complete.\n\nSensors indicate [xenos_on_ship_uncontained ? "[xenos_on_ship_uncontained]" : "no"] unknown lifeform signature[!xenos_on_ship_uncontained || xenos_on_ship_uncontained > 1 ? "s":""] present on the ship[xenos_on_ship_uncontained && xenos_ship_location ? ", including one in [xenos_ship_location]," : ""] and [fake_xenos_on_planet ? "approximately [fake_xenos_on_planet]" : "no"] signature[!fake_xenos_on_planet || fake_xenos_on_planet > 1 ? "s":""] located elsewhere[fake_xenos_on_planet && xenos_planet_location ? ", including one in [xenos_planet_location]":""]."
 
-	link.log_ares_bioscan(name, input) //if interface is down, bioscan still logged, just have to go read it.
 	if(forced || ares_can_log())
+		link.log_ares_bioscan(name, input) //if interface is down, bioscan still logged, just have to go read it.
+	if(forced || ares_can_interface())
 		marine_announcement(input, name, 'sound/AI/bioscan.ogg', logging = ARES_LOG_NONE)
 
 /// The announcement to all Xenos. Slightly off for the human ship, accurate otherwise.

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -122,8 +122,7 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 		var/name = "[MAIN_AI_SYSTEM] Bioscan Failure"
 		var/input = "Bioscan failure detected. Investigation into Bioscan subsystem recommended."
 		marine_announcement(input, name, 'sound/misc/interference.ogg', logging = ARES_LOG_NONE)
-		if(ares_can_log())
-			link.log_ares_bioscan(name, input)
+		link.log_ares_bioscan(name, input)
 		return
 
 	//Adjust the randomness there so everyone gets the same thing
@@ -132,8 +131,8 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 	var/name = "[MAIN_AI_SYSTEM] Bioscan Status"
 	var/input = "Bioscan complete.\n\nSensors indicate [xenos_on_ship_uncontained ? "[xenos_on_ship_uncontained]" : "no"] unknown lifeform signature[!xenos_on_ship_uncontained || xenos_on_ship_uncontained > 1 ? "s":""] present on the ship[xenos_on_ship_uncontained && xenos_ship_location ? ", including one in [xenos_ship_location]," : ""] and [fake_xenos_on_planet ? "approximately [fake_xenos_on_planet]" : "no"] signature[!fake_xenos_on_planet || fake_xenos_on_planet > 1 ? "s":""] located elsewhere[fake_xenos_on_planet && xenos_planet_location ? ", including one in [xenos_planet_location]":""]."
 
+	link.log_ares_bioscan(name, input) //if interface is down, bioscan still logged, just have to go read it.
 	if(forced || ares_can_log())
-		link.log_ares_bioscan(name, input)
 		marine_announcement(input, name, 'sound/AI/bioscan.ogg', logging = ARES_LOG_NONE)
 
 /// The announcement to all Xenos. Slightly off for the human ship, accurate otherwise.

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -135,8 +135,12 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 
 	if(forced || ares_can_log())
 		link.log_ares_bioscan(name, input) //if interface is down, bioscan still logged, just have to go read it.
+	else
+		message_admins("An ARES Bioscan has succeeded, but was not logged into ARES Bioscan Logs.")
 	if(forced || ares_can_interface())
 		marine_announcement(input, name, 'sound/AI/bioscan.ogg', logging = ARES_LOG_NONE)
+	else
+		message_admins("An ARES Bioscan has succeeded, but was not announced. Xenos on Ship: [xenos_on_ship_uncontained]. Xenos on Planet: [xenos_on_planet](Fake: [fake_xenos_on_planet]).") //include info incase needed.
 
 /// The announcement to all Xenos. Slightly off for the human ship, accurate otherwise.
 /datum/bioscan_data/proc/qm_bioscan(variance = 2)

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -106,7 +106,7 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 
 
 /// This will do something after Project ARES.
-/datum/bioscan_data/proc/can_ares_bioscan()
+/datum/bioscan_data/proc/ares_can_bioscan()
 	var/datum/ares_link/link = GLOB.ares_link
 	if(!istype(link))
 		return FALSE
@@ -116,7 +116,7 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 
 /// The announcement to all Humans. Slightly off for the planet and elsewhere, accurate for the ship.
 /datum/bioscan_data/proc/ares_bioscan(forced = FALSE, variance = 2)
-	if(!forced && !can_ares_bioscan())
+	if(!forced && !ares_can_bioscan())
 		message_admins("An ARES Bioscan has failed.")
 		marine_announcement("Bioscan failure detected. Investigation into Bioscan subsystem recommended.", "[MAIN_AI_SYSTEM] Bioscan Failure", 'sound/AI/bioscan.ogg', logging = ARES_LOG_MAIN)
 		return

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -121,7 +121,8 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 		message_admins("An ARES Bioscan has failed.")
 		var/name = "[MAIN_AI_SYSTEM] Bioscan Status"
 		var/input = "Bioscan failed. \n\nInvestigation into Bioscan subsystem recommended."
-		marine_announcement(input, name, 'sound/misc/interference.ogg', logging = ARES_LOG_NONE)
+		if(ares_can_log())
+			marine_announcement(input, name, 'sound/misc/interference.ogg', logging = ARES_LOG_NONE)
 		link.log_ares_bioscan(name, input)
 		return
 

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -133,6 +133,8 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 	var/name = "[MAIN_AI_SYSTEM] Bioscan Status"
 	var/input = "Bioscan complete.\n\nSensors indicate [xenos_on_ship_uncontained ? "[xenos_on_ship_uncontained]" : "no"] unknown lifeform signature[!xenos_on_ship_uncontained || xenos_on_ship_uncontained > 1 ? "s":""] present on the ship[xenos_on_ship_uncontained && xenos_ship_location ? ", including one in [xenos_ship_location]," : ""] and [fake_xenos_on_planet ? "approximately [fake_xenos_on_planet]" : "no"] signature[!fake_xenos_on_planet || fake_xenos_on_planet > 1 ? "s":""] located elsewhere[fake_xenos_on_planet && xenos_planet_location ? ", including one in [xenos_planet_location]":""]."
 
+	log_game("BIOSCAN: ARES bioscan completed. [input]")
+
 	if(forced || ares_can_log())
 		link.log_ares_bioscan(name, input) //if interface is down, bioscan still logged, just have to go read it.
 	if(forced || ares_can_interface())

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -122,7 +122,7 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 		var/name = "[MAIN_AI_SYSTEM] Bioscan Failure"
 		var/input = "Bioscan failure detected. Investigation into Bioscan subsystem recommended."
 		marine_announcement(input, name, 'sound/misc/interference.ogg', logging = ARES_LOG_NONE)
-		if(forced || ares_can_log())
+		if(ares_can_log())
 			link.log_ares_bioscan(name, input)
 		return
 

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -116,6 +116,7 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 
 /// The announcement to all Humans. Slightly off for the planet and elsewhere, accurate for the ship.
 /datum/bioscan_data/proc/ares_bioscan(forced = FALSE, variance = 2)
+	var/datum/ares_link/link = GLOB.ares_link
 	if(!forced && !ares_can_bioscan())
 		message_admins("An ARES Bioscan has failed.")
 		var/name = "[MAIN_AI_SYSTEM] Bioscan Failure"
@@ -131,7 +132,6 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 	var/name = "[MAIN_AI_SYSTEM] Bioscan Status"
 	var/input = "Bioscan complete.\n\nSensors indicate [xenos_on_ship_uncontained ? "[xenos_on_ship_uncontained]" : "no"] unknown lifeform signature[!xenos_on_ship_uncontained || xenos_on_ship_uncontained > 1 ? "s":""] present on the ship[xenos_on_ship_uncontained && xenos_ship_location ? ", including one in [xenos_ship_location]," : ""] and [fake_xenos_on_planet ? "approximately [fake_xenos_on_planet]" : "no"] signature[!fake_xenos_on_planet || fake_xenos_on_planet > 1 ? "s":""] located elsewhere[fake_xenos_on_planet && xenos_planet_location ? ", including one in [xenos_planet_location]":""]."
 
-	var/datum/ares_link/link = GLOB.ares_link
 	if(forced || ares_can_log())
 		link.log_ares_bioscan(name, input)
 		marine_announcement(input, name, 'sound/AI/bioscan.ogg', logging = ARES_LOG_NONE)

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -127,8 +127,8 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 	var/input = "Bioscan complete.\n\nSensors indicate [xenos_on_ship_uncontained ? "[xenos_on_ship_uncontained]" : "no"] unknown lifeform signature[!xenos_on_ship_uncontained || xenos_on_ship_uncontained > 1 ? "s":""] present on the ship[xenos_on_ship_uncontained && xenos_ship_location ? ", including one in [xenos_ship_location]," : ""] and [fake_xenos_on_planet ? "approximately [fake_xenos_on_planet]" : "no"] signature[!fake_xenos_on_planet || fake_xenos_on_planet > 1 ? "s":""] located elsewhere[fake_xenos_on_planet && xenos_planet_location ? ", including one in [xenos_planet_location]":""]."
 
 	var/datum/ares_link/link = GLOB.ares_link
-	link.log_ares_bioscan(name, input)
 	if(forced || ares_can_log())
+		link.log_ares_bioscan(name, input)
 		marine_announcement(input, name, 'sound/AI/bioscan.ogg', logging = ARES_LOG_NONE)
 
 /// The announcement to all Xenos. Slightly off for the human ship, accurate otherwise.

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -139,6 +139,8 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 		link.log_ares_bioscan(name, input) //if interface is down, bioscan still logged, just have to go read it.
 	if(forced || ares_can_interface())
 		marine_announcement(input, name, 'sound/AI/bioscan.ogg', logging = ARES_LOG_NONE)
+	else
+	message_admins("An ARES Bioscan has succeeded, but was not announced.")
 
 /// The announcement to all Xenos. Slightly off for the human ship, accurate otherwise.
 /datum/bioscan_data/proc/qm_bioscan(variance = 2)

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -135,12 +135,8 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 
 	if(forced || ares_can_log())
 		link.log_ares_bioscan(name, input) //if interface is down, bioscan still logged, just have to go read it.
-	else
-		message_admins("An ARES Bioscan has succeeded, but was not logged into ARES Bioscan Logs.")
 	if(forced || ares_can_interface())
 		marine_announcement(input, name, 'sound/AI/bioscan.ogg', logging = ARES_LOG_NONE)
-	else
-		message_admins("An ARES Bioscan has succeeded, but was not announced. Xenos on Ship: [xenos_on_ship_uncontained]. Xenos on Planet: [xenos_on_planet](Fake: [fake_xenos_on_planet]).") //include info incase needed.
 
 /// The announcement to all Xenos. Slightly off for the human ship, accurate otherwise.
 /datum/bioscan_data/proc/qm_bioscan(variance = 2)

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -119,8 +119,8 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 	var/datum/ares_link/link = GLOB.ares_link
 	if(!forced && !ares_can_bioscan())
 		message_admins("An ARES Bioscan has failed.")
-		var/name = "[MAIN_AI_SYSTEM] Bioscan Failure"
-		var/input = "Bioscan failure detected. Investigation into Bioscan subsystem recommended."
+		var/name = "[MAIN_AI_SYSTEM] Bioscan Status"
+		var/input = "Bioscan failed. \n\nInvestigation into Bioscan subsystem recommended."
 		marine_announcement(input, name, 'sound/misc/interference.ogg', logging = ARES_LOG_NONE)
 		link.log_ares_bioscan(name, input)
 		return

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -122,7 +122,7 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 		var/name = "[MAIN_AI_SYSTEM] Bioscan Failure"
 		var/input = "Bioscan failure detected. Investigation into Bioscan subsystem recommended."
 		marine_announcement(input, name, 'sound/misc/interference.ogg', logging = ARES_LOG_NONE)
-		if(ares_can_log())
+		if(forced || ares_can_log())
 			link.log_ares_bioscan(name, input)
 		return
 

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -118,6 +118,7 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 /datum/bioscan_data/proc/ares_bioscan(forced = FALSE, variance = 2)
 	if(!forced && !can_ares_bioscan())
 		message_admins("An ARES Bioscan has failed.")
+		marine_announcement("Bioscan failure detected. Investigation into Bioscan subsystem recommended.", "[MAIN_AI_SYSTEM] Bioscan Failure", 'sound/AI/bioscan.ogg', logging = ARES_LOG_MAIN)
 		return
 
 	//Adjust the randomness there so everyone gets the same thing

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -128,7 +128,7 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 
 	var/datum/ares_link/link = GLOB.ares_link
 	link.log_ares_bioscan(name, input)
-	if(forced || (link.p_interface && !link.p_interface.inoperable()))
+	if(forced || ares_can_log())
 		marine_announcement(input, name, 'sound/AI/bioscan.ogg', logging = ARES_LOG_NONE)
 
 /// The announcement to all Xenos. Slightly off for the human ship, accurate otherwise.

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -118,7 +118,11 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 /datum/bioscan_data/proc/ares_bioscan(forced = FALSE, variance = 2)
 	if(!forced && !ares_can_bioscan())
 		message_admins("An ARES Bioscan has failed.")
-		marine_announcement("Bioscan failure detected. Investigation into Bioscan subsystem recommended.", "[MAIN_AI_SYSTEM] Bioscan Failure", 'sound/AI/bioscan.ogg', logging = ARES_LOG_MAIN)
+		var/name = "[MAIN_AI_SYSTEM] Bioscan Failure"
+		var/input = "Bioscan failure detected. Investigation into Bioscan subsystem recommended."
+		marine_announcement(input, name, 'sound/misc/interference.ogg', logging = ARES_LOG_NONE)
+		if(ares_can_log())
+			link.log_ares_bioscan(name, input)
 		return
 
 	//Adjust the randomness there so everyone gets the same thing

--- a/code/game/bioscans.dm
+++ b/code/game/bioscans.dm
@@ -140,7 +140,7 @@ GLOBAL_DATUM_INIT(bioscan_data, /datum/bioscan_data, new)
 	if(forced || ares_can_interface())
 		marine_announcement(input, name, 'sound/AI/bioscan.ogg', logging = ARES_LOG_NONE)
 	else
-	message_admins("An ARES Bioscan has succeeded, but was not announced.")
+		message_admins("An ARES Bioscan has succeeded, but was not announced.")
 
 /// The announcement to all Xenos. Slightly off for the human ship, accurate otherwise.
 /datum/bioscan_data/proc/qm_bioscan(variance = 2)

--- a/code/game/machinery/ARES/ARES_procs.dm
+++ b/code/game/machinery/ARES/ARES_procs.dm
@@ -86,7 +86,7 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 		return FALSE
 	if(processor && !processor.inoperable())
 		return TRUE
-	return FALSE //interface not found or is broken
+	return FALSE //interface processor not found or is broken
 
 /proc/ares_can_log()
 	var/obj/structure/machinery/computer/ares_console/interface = GLOB.ares_link.interface

--- a/code/game/machinery/ARES/ARES_procs.dm
+++ b/code/game/machinery/ARES/ARES_procs.dm
@@ -81,10 +81,10 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 			playsound_client(listener.client, sound('sound/misc/interference.ogg'), listener, vol = 45)
 
 /proc/ares_can_interface()
-	var/obj/structure/machinery/ares/processor/interface/interface = GLOB.ares_link.p_interface
+	var/obj/structure/machinery/ares/processor/interface/processor = GLOB.ares_link.p_interface
 	if(!istype(GLOB.ares_link))
 		return FALSE
-	if(interface && !interface.inoperable())
+	if(processor && !processor.inoperable())
 		return TRUE
 	return FALSE //interface not found or is broken
 

--- a/code/game/machinery/ARES/ARES_procs.dm
+++ b/code/game/machinery/ARES/ARES_procs.dm
@@ -82,6 +82,13 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 		if(listener.hear_apollo())//Only plays sound to mobs and not observers, to reduce spam.
 			playsound_client(listener.client, sound('sound/misc/interference.ogg'), listener, vol = 45)
 
+/proc/ares_can_interface()
+	var/obj/structure/machinery/ares/processor/interface/interface = GLOB.ares_link.p_interface
+	if(interface && !interface.inoperable())
+		return TRUE
+	return FALSE //interface not found or is broken
+
+
 // ------ ARES Interface Procs ------ //
 /obj/structure/machinery/computer/proc/get_ares_access(obj/item/card/id/card)
 	if(ACCESS_ARES_DEBUG in card.access)

--- a/code/game/machinery/ARES/ARES_procs.dm
+++ b/code/game/machinery/ARES/ARES_procs.dm
@@ -84,12 +84,16 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 
 /proc/ares_can_interface()
 	var/obj/structure/machinery/ares/processor/interface/interface = GLOB.ares_link.p_interface
+	if(!istype(GLOB.ares_link))
+		return FALSE
 	if(interface && !interface.inoperable())
 		return TRUE
 	return FALSE //interface not found or is broken
 
 /proc/ares_can_log()
 	var/obj/structure/machinery/computer/ares_console/interface = GLOB.ares_link.interface
+	if(!istype(GLOB.ares_link))
+		return FALSE
 	if(interface && !interface.inoperable())
 		return TRUE
 	return FALSE //ares interface not found or is broken

--- a/code/game/machinery/ARES/ARES_procs.dm
+++ b/code/game/machinery/ARES/ARES_procs.dm
@@ -54,8 +54,6 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 	link.apollo_log.Add("[worldtime2text()]: [speaker], '[message]'")
 
 /datum/ares_link/proc/log_ares_bioscan(title, input)
-	if(!p_bioscan || p_bioscan.inoperable() || !interface)
-		return FALSE
 	interface.records_bioscan.Add(new /datum/ares_record/bioscan(title, input))
 
 /datum/ares_link/proc/log_ares_bombardment(mob/living/user, ob_name, coordinates)

--- a/code/game/machinery/ARES/ARES_procs.dm
+++ b/code/game/machinery/ARES/ARES_procs.dm
@@ -88,6 +88,11 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 		return TRUE
 	return FALSE //interface not found or is broken
 
+/proc/ares_can_log()
+	var/obj/structure/machinery/computer/ares_console/interface = GLOB.ares_link.interface
+	if(interface && !interface.inoperable())
+		return TRUE
+	return FALSE //ares interface not found or is broken
 
 // ------ ARES Interface Procs ------ //
 /obj/structure/machinery/computer/proc/get_ares_access(obj/item/card/id/card)

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -536,7 +536,7 @@
 		return FALSE
 
 	if(!ares_can_interface())
-		var/prompt = tgui_alert(src, "ARES Interface is offline or destroyed, send the message anyways?", "Choose.", list("Yes", "No"), 20 SECONDS)
+		var/prompt = tgui_alert(src, "ARES interface processor is offline or destroyed, send the message anyways?", "Choose.", list("Yes", "No"), 20 SECONDS)
 		if(prompt == "No")
 			to_chat(usr, SPAN_WARNING("[MAIN_AI_SYSTEM] is not responding. It's interface processor may be offline or destroyed."))
 			return
@@ -579,7 +579,7 @@
 	if(!input)
 		return FALSE
 	if(!ares_can_interface())
-		var/prompt = tgui_alert(src, "ARES Interface is offline or destroyed, send the message anyways?", "Choose.", list("Yes", "No"), 20 SECONDS)
+		var/prompt = tgui_alert(src, "ARES interface processor is offline or destroyed, send the message anyways?", "Choose.", list("Yes", "No"), 20 SECONDS)
 		if(prompt == "No")
 			to_chat(usr, SPAN_WARNING("[MAIN_AI_SYSTEM] is not responding. It's interface processor may be offline or destroyed."))
 			return

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -535,9 +535,8 @@
 	if(!input)
 		return FALSE
 
-	var/datum/ares_link/link = GLOB.ares_link
-	if(link.p_interface.inoperable())
-		to_chat(usr, SPAN_WARNING("[MAIN_AI_SYSTEM] is not responding. It may be offline or destroyed."))
+	if(!ares_can_interface())
+		to_chat(usr, SPAN_WARNING("[MAIN_AI_SYSTEM] is not responding. Interface processor may be offline or destroyed."))
 		return
 
 	ai_announcement(input)
@@ -575,14 +574,13 @@
 	var/input = input(usr, "This is an announcement type message from the ship's AI. This will be announced to every conscious human on Almayer z-level. Be aware, this will work even if ARES unpowered/destroyed. Check with online staff before you send this.", "What?", "") as message|null
 	if(!input)
 		return FALSE
-	for(var/obj/structure/machinery/ares/processor/interface/processor in machines)
-		if(processor.inoperable())
-			to_chat(usr, SPAN_WARNING("[MAIN_AI_SYSTEM] is not responding. It may be offline or destroyed."))
-			return
+	if(!ares_can_interface())
+		to_chat(usr, SPAN_WARNING("[MAIN_AI_SYSTEM] is not responding. Interface processor may be offline or destroyed."))
+		return
 
-		shipwide_ai_announcement(input)
-		message_admins("[key_name_admin(src)] has created an AI shipwide report")
-		log_admin("[key_name_admin(src)] AI shipwide report: [input]")
+	shipwide_ai_announcement(input)
+	message_admins("[key_name_admin(src)] has created an AI shipwide report")
+	log_admin("[key_name_admin(src)] AI shipwide report: [input]")
 
 /client/proc/cmd_admin_create_predator_report()
 	set name = "Report: Yautja AI"

--- a/code/modules/admin/tabs/event_tab.dm
+++ b/code/modules/admin/tabs/event_tab.dm
@@ -536,8 +536,10 @@
 		return FALSE
 
 	if(!ares_can_interface())
-		to_chat(usr, SPAN_WARNING("[MAIN_AI_SYSTEM] is not responding. Interface processor may be offline or destroyed."))
-		return
+		var/prompt = tgui_alert(src, "ARES Interface is offline or destroyed, send the message anyways?", "Choose.", list("Yes", "No"), 20 SECONDS)
+		if(prompt == "No")
+			to_chat(usr, SPAN_WARNING("[MAIN_AI_SYSTEM] is not responding. It's interface processor may be offline or destroyed."))
+			return
 
 	ai_announcement(input)
 	message_admins("[key_name_admin(src)] has created an AI comms report")
@@ -557,8 +559,10 @@
 
 	var/datum/ares_link/link = GLOB.ares_link
 	if(link.p_apollo.inoperable())
-		to_chat(usr, SPAN_WARNING("[MAIN_AI_SYSTEM] is not responding. It may be offline or destroyed."))
-		return FALSE
+		var/prompt = tgui_alert(src, "ARES APOLLO processor is offline or destroyed, send the message anyways?", "Choose.", list("Yes", "No"), 20 SECONDS)
+		if(prompt == "No")
+			to_chat(usr, SPAN_WARNING("[MAIN_AI_SYSTEM] is not responding. It's APOLLO processor may be offline or destroyed."))
+			return FALSE
 
 	ares_apollo_talk(input)
 	message_admins("[key_name_admin(src)] has created an AI APOLLO report")
@@ -575,8 +579,10 @@
 	if(!input)
 		return FALSE
 	if(!ares_can_interface())
-		to_chat(usr, SPAN_WARNING("[MAIN_AI_SYSTEM] is not responding. Interface processor may be offline or destroyed."))
-		return
+		var/prompt = tgui_alert(src, "ARES Interface is offline or destroyed, send the message anyways?", "Choose.", list("Yes", "No"), 20 SECONDS)
+		if(prompt == "No")
+			to_chat(usr, SPAN_WARNING("[MAIN_AI_SYSTEM] is not responding. It's interface processor may be offline or destroyed."))
+			return
 
 	shipwide_ai_announcement(input)
 	message_admins("[key_name_admin(src)] has created an AI shipwide report")


### PR DESCRIPTION
# About the pull request

add ares_can_interface and ares_can_log procs, and allows communications to go through if subsystems are offline (only if admin called)

# Explain why it's good for the game

Code procs gud. Event players having anti-grief protection is good

# Changelog

Don't think this does anything but whatever

:cl:
add: ARES now announces when Bioscan fails.
code: new procs to see if ARES can talk, or log something. Bioscan proc renamed for consistency. 
admin: Admins can now force an ARES announcement or communication if subsystem is offline.
/:cl:
