### PR TITLE
Adds General Quarters

### DIFF
--- a/code/game/machinery/ARES/ARES_procs.dm
+++ b/code/game/machinery/ARES/ARES_procs.dm
@@ -502,7 +502,7 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 		// -- Emergency Buttons -- //
 		if("general_quarters")
 			if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA)
-				to_chat(usr, SPAN_WARNING("Security is already red or above, General Quarters cannot be called."))
+				to_chat(usr, SPAN_WARNING("Alert level is already red or above, General Quarters cannot be called."))
 				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
 				return FALSE
 			set_security_level(2, no_sound=1, announce=0)

--- a/code/game/machinery/ARES/ARES_procs.dm
+++ b/code/game/machinery/ARES/ARES_procs.dm
@@ -500,6 +500,19 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 			current_menu = "read_deleted"
 
 		// -- Emergency Buttons -- //
+		if("general_quarters")
+			if(security_level == SEC_LEVEL_RED || security_level == SEC_LEVEL_DELTA)
+				to_chat(usr, SPAN_WARNING("Security is already red or above, General Quarters cannot be called."))
+				playsound(src, 'sound/machines/buzz-two.ogg', 15, 1)
+				return FALSE
+			set_security_level(2, no_sound=1, announce=0)
+			shipwide_ai_announcement("ATTENTION! GENERAL QUARTERS. ALL HANDS, MAN YOUR BATTLESTATIONS.", MAIN_AI_SYSTEM, 'sound/effects/GQfullcall.ogg')
+			log_game("[key_name(usr)] has called for general quarters via ARES.")
+			message_admins("[key_name_admin(usr)] has called for general quarters via ARES.")
+			var/datum/ares_link/link = GLOB.ares_link
+			link.log_ares_security("General Quarters", "[last_login] has called for general quarters via ARES.")
+			. = TRUE
+
 		if("evacuation_start")
 			if(security_level < SEC_LEVEL_RED)
 				to_chat(usr, SPAN_WARNING("The ship must be under red alert in order to enact evacuation procedures."))

--- a/tgui/packages/tgui/interfaces/AresInterface.js
+++ b/tgui/packages/tgui/interfaces/AresInterface.js
@@ -1371,6 +1371,8 @@ const Emergency = (props, context) => {
     nuketimelock,
     nuke_available,
   } = data;
+  const canQuarters = alert_level < 2;
+  let quarters_reason = 'Call for General Quarters.';
   const minimumEvacTime = worldtime > distresstimelock;
   const distressCooldown = worldtime < distresstime;
   const canDistress = alert_level === 2 && !distressCooldown && minimumEvacTime;
@@ -1452,6 +1454,20 @@ const Emergency = (props, context) => {
 
       <h1 align="center">Emergency Protocols</h1>
       <Flex align="center" justify="center" height="50%" direction="column">
+        <Button.Confirm
+          content="Call General Quarters"
+          tooltip={quarters_reason}
+          icon="shuttle-space"
+          color="red"
+          width="40vw"
+          textAlign="center"
+          fontSize="1.5rem"
+          p="1rem"
+          mt="5rem"
+          bold
+          onClick={() => act('general_quarters')}
+          disabled={!canQuarters}
+        />
         <Button.Confirm
           content="Initiate Evacuation"
           tooltip={evac_reason}

--- a/tgui/packages/tgui/interfaces/AresInterface.js
+++ b/tgui/packages/tgui/interfaces/AresInterface.js
@@ -1457,7 +1457,7 @@ const Emergency = (props, context) => {
         <Button.Confirm
           content="Call General Quarters"
           tooltip={quarters_reason}
-          icon="shuttle-space"
+          icon="triangle-exclamation"
           color="red"
           width="40vw"
           textAlign="center"


### PR DESCRIPTION

# About the pull request

Adds General Quarters emergency protocol to ARES interface 

# Explain why it's good for the game

A different way to call Red Alert by high ranking crew, utilizes not often used general quarters noise and announcement.

# Changelog

:cl:
add: new emergency protocol from ARES; call General Quarters, which sets the ship to immediate Red Alert.
/:cl:
