### PR TITLE
Access Ticket Tweaks

### DIFF
--- a/code/game/machinery/ARES/ARES_procs.dm
+++ b/code/game/machinery/ARES/ARES_procs.dm
@@ -984,8 +984,13 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 			return TRUE
 
 		if("new_access")
+			var/ticket_holder
 			var/priority_report = FALSE
-			var/ticket_holder = tgui_input_text(operator, "Who is the ticket for? (Please use precise name, with punctuation and capitalisation.)", "Ticket Holder", encode = FALSE)
+			var/is_self = tgui_alert(operator, "Is this request for yourself?", "Ticket Holder", list("Yes", "No"))
+			if(is_self != "Yes")
+				ticket_holder = tgui_input_text(operator, "Who is the ticket for? (Please use precise name, with punctuation and capitalisation.)", "Ticket Holder", encode = FALSE)
+			else
+				ticket_holder = last_login
 			if(!ticket_holder)
 				return FALSE
 			var/details = tgui_input_text(operator, "What is the purpose of this access ticket?", "Ticket Details", encode = FALSE)

--- a/code/game/machinery/ARES/ARES_procs.dm
+++ b/code/game/machinery/ARES/ARES_procs.dm
@@ -987,9 +987,9 @@ GLOBAL_LIST_INIT(maintenance_categories, list(
 			var/ticket_holder
 			var/priority_report = FALSE
 			var/is_self = tgui_alert(operator, "Is this request for yourself?", "Ticket Holder", list("Yes", "No"))
-			if(is_self != "Yes")
+			if(is_self == "No")
 				ticket_holder = tgui_input_text(operator, "Who is the ticket for? (Please use precise name, with punctuation and capitalisation.)", "Ticket Holder", encode = FALSE)
-			else
+			else if(is_self == "Yes")
 				ticket_holder = last_login
 			if(!ticket_holder)
 				return FALSE

--- a/tgui/packages/tgui/interfaces/WorkingJoe.js
+++ b/tgui/packages/tgui/interfaces/WorkingJoe.js
@@ -727,19 +727,19 @@ const AccessRequests = (props, context) => {
           </Flex>
         )}
         {access_tickets.map((ticket, i) => {
-          let view_status = 'Ticket is pending assignment.';
+          let view_status = 'Access Ticket is pending assignment.';
           let view_icon = 'circle-question';
           if (ticket.status === 'assigned') {
-            view_status = 'Ticket is assigned.';
+            view_status = 'Access Ticket is assigned.';
             view_icon = 'circle-plus';
           } else if (ticket.status === 'rejected') {
-            view_status = 'Ticket has been rejected.';
+            view_status = 'Access Ticket has been rejected.';
             view_icon = 'circle-xmark';
           } else if (ticket.status === 'cancelled') {
-            view_status = 'Ticket was cancelled by reporter.';
+            view_status = 'Access Ticket was cancelled by reporter.';
             view_icon = 'circle-stop';
           } else if (ticket.status === 'completed') {
-            view_status = 'Ticket has been successfully resolved.';
+            view_status = 'Access Ticket has been successfully resolved.';
             view_icon = 'circle-check';
           }
           let can_cancel = 'Yes';

--- a/tgui/packages/tgui/interfaces/WorkingJoe.js
+++ b/tgui/packages/tgui/interfaces/WorkingJoe.js
@@ -721,6 +721,9 @@ const AccessRequests = (props, context) => {
             <Flex.Item bold width="6rem" shrink="0" mr="1rem">
               Time
             </Flex.Item>
+            <Flex.Item width="8rem" mr="1rem" bold>
+              For
+            </Flex.Item>
             <Flex.Item width="40rem" bold>
               Details
             </Flex.Item>
@@ -763,6 +766,9 @@ const AccessRequests = (props, context) => {
               )}
               <Flex.Item italic width="6rem" shrink="0" mr="1rem">
                 {ticket.time}
+              </Flex.Item>
+              <Flex.Item width="8rem" mr="1rem">
+                {ticket.title}
               </Flex.Item>
               <Flex.Item width="40rem" shrink="0" textAlign="left">
                 {ticket.details}


### PR DESCRIPTION
# About the pull request

Simplify creating Access Ticket and adjustments to messages for ticket status. Access Ticket menu now shows who it is for.

# Changelog
:cl:
qol: When creating an Access Ticket using APOLLO, you can have the current login name be used.
ui: Access Ticket menu now shows who Access Ticket is for.
/:cl:
