### PR TITLE
Possible solution to ovipositor runtime.

### DIFF
--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -1364,10 +1364,10 @@ SUBSYSTEM_DEF(minimaps)
 	var/should_be_live = FALSE
 	if(xeno == xeno.hive?.living_xeno_queen)
 		should_be_live = TRUE // Queens always get live
-	else if(xeno.hive?.living_xeno_queen?.ovipositor)
-		should_be_live = TRUE // Queen is on ovipositor, all xenos get live
 	else if(!xeno.hive?.tacmap_requires_queen_ovi)
 		should_be_live = TRUE // This Hive doesn't require queen ovi (forsaken for example)
+	else if(xeno.hive?.living_xeno_queen?.ovipositor)
+		should_be_live = TRUE // Queen is on ovipositor, all xenos get live
 
 	// If live status changed, reset the map so it gets recreated with correct mode
 	if(live != should_be_live)


### PR DESCRIPTION
It should first check if hive require queen on ovipositor before checking if queen is alive on ovipositor to use tacmap.

Might fix runtime for ovipositor check.

I am not sure if it actually works or not, i was not able to trigger the runtime in anyway on private instance.