### PR TITLE
Adds comma, so CI can calm down.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/hive_status.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_status.dm
@@ -1868,7 +1868,7 @@
 	)
 
 	restricted_castes = list(
-		PATHOGEN_CREATURE_HARBINGER = 2
+		PATHOGEN_CREATURE_HARBINGER = 2,
 	)
 
 	tier_slot_multiplier = 0.8 // Experimental change.


### PR DESCRIPTION
CI check say is ULTRA BAD that there is no comma at end of PATHOGEN_CREATURE_HARBINGER = 2
